### PR TITLE
Remove reference to "contributing guidelines" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For detailed API documentation and advanced usage, visit [rqlite-rs documentatio
 
 ## Contributing
 
-Contributions are welcome! Please refer to the contributing guidelines for more information.
+Contributions are welcome!
 
 ## License
 


### PR DESCRIPTION
Hello, the README mentions the presence of "contributing guidelines", however there aren't any such guidelines included in the repository. Hence I've removed the mention from the README. I've also added a neat little line break at the end of the file for consistency. Have a nice day!