### PR TITLE
feat(rqlite-rs): allow optional parameters (#15)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -39,3 +39,8 @@ doc-scrape-examples = true
 name = "https"
 path = "https.rs"
 doc-scrape-examples = true
+
+[[example]]
+name = "option"
+path = "option.rs"
+doc-scrape-examples = true

--- a/examples/option.rs
+++ b/examples/option.rs
@@ -1,0 +1,65 @@
+use rqlite_rs::prelude::*;
+
+#[derive(FromRow)]
+pub struct OptionalRow {
+    id: i32,
+    optional: Option<i32>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = RqliteClientBuilder::new()
+        .known_host("localhost:4001")
+        .build()?;
+
+    let create_table_query = rqlite_rs::query!(
+        "CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, optional INTEGER)"
+    )?;
+
+    client.exec(create_table_query).await?;
+
+    let example_rows = [
+        OptionalRow {
+            id: 1,
+            optional: None,
+        },
+        OptionalRow {
+            id: 2,
+            optional: Some(2),
+        },
+    ];
+
+    let queries = example_rows
+        .iter()
+        .map(|row| {
+            rqlite_rs::query!(
+                "INSERT INTO test (id, optional) VALUES (?, ?)",
+                row.id,
+                row.optional
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let res = client.batch(queries).await?;
+
+    println!("Batch result: {:?}", res);
+
+    let select_query = rqlite_rs::query!("SELECT * FROM test")?;
+
+    let rows = client
+        .fetch(select_query)
+        .await?
+        .into_typed::<OptionalRow>()?;
+
+    rows.iter().for_each(|row| {
+        println!("ID: {}, Optional: {:?}", row.id, row.optional);
+    });
+
+    let drop_table_query = rqlite_rs::query!("DROP TABLE test")?;
+
+    client.exec(drop_table_query).await?;
+
+    println!("Successfully cleaned up");
+
+    Ok(())
+}

--- a/rqlite-rs/src/client.rs
+++ b/rqlite-rs/src/client.rs
@@ -167,7 +167,10 @@ impl RqliteClient {
         }
     }
 
-    async fn exec_query<T>(&self, q: query::RqliteQuery) -> Result<RqliteResult<T>, RequestError>
+    async fn exec_query<'a, T>(
+        &'a self,
+        q: query::RqliteQuery<'a>,
+    ) -> Result<RqliteResult<T>, RequestError>
     where
         T: serde::de::DeserializeOwned + Clone,
     {
@@ -217,9 +220,9 @@ impl RqliteClient {
 
     /// Executes a query that returns results.
     /// Returns a vector of [`Row`]s if the query was successful, otherwise an error.
-    pub async fn fetch<Q>(&self, q: Q) -> Result<Vec<Row>, RequestError>
+    pub async fn fetch<'a, Q>(&self, q: Q) -> Result<Vec<Row>, RequestError>
     where
-        Q: TryInto<RqliteQuery>,
+        Q: TryInto<RqliteQuery<'a>>,
         RequestError: From<Q::Error>,
     {
         let result = self
@@ -235,9 +238,9 @@ impl RqliteClient {
     /// Executes a query that does not return any results.
     /// Returns the [`QueryResult`] if the query was successful, otherwise an error.
     /// Is primarily used for `INSERT`, `UPDATE`, `DELETE` and `CREATE` queries.
-    pub async fn exec<Q>(&self, q: Q) -> Result<QueryResult, RequestError>
+    pub async fn exec<'a, Q>(&self, q: Q) -> Result<QueryResult, RequestError>
     where
-        Q: TryInto<RqliteQuery>,
+        Q: TryInto<RqliteQuery<'a>>,
         RequestError: From<Q::Error>,
     {
         let query_result = self.exec_query::<QueryResult>(q.try_into()?).await?;
@@ -256,9 +259,12 @@ impl RqliteClient {
     /// If a query fails, the corresponding result will contain an error.
     ///
     /// For more information on batch queries, see the [rqlite documentation](https://rqlite.io/docs/api/bulk-api/).
-    pub async fn batch<Q>(&self, qs: Vec<Q>) -> Result<Vec<RqliteResult<BatchResult>>, RequestError>
+    pub async fn batch<'a, Q>(
+        &self,
+        qs: Vec<Q>,
+    ) -> Result<Vec<RqliteResult<BatchResult>>, RequestError>
     where
-        Q: TryInto<RqliteQuery>,
+        Q: TryInto<RqliteQuery<'a>>,
         RequestError: From<Q::Error>,
     {
         let queries = qs
@@ -292,12 +298,12 @@ impl RqliteClient {
     /// Returns a vector of [`RqliteResult`]s.
     ///
     /// For more information on transactions, see the [rqlite documentation](https://rqlite.io/docs/api/api/#transactions).
-    pub async fn transaction<Q>(
+    pub async fn transaction<'a, Q>(
         &self,
         qs: Vec<Q>,
     ) -> Result<Vec<RqliteResult<QueryResult>>, RequestError>
     where
-        Q: TryInto<RqliteQuery>,
+        Q: TryInto<RqliteQuery<'a>>,
         RequestError: From<Q::Error>,
     {
         let queries = qs
@@ -334,9 +340,9 @@ impl RqliteClient {
     /// This results in much higher write performance.
     ///
     /// For more information on queued queries, see the [rqlite documentation](https://rqlite.io/docs/api/queued-writes/).
-    pub async fn queue<Q>(&self, qs: Vec<Q>) -> Result<(), RequestError>
+    pub async fn queue<'a, Q>(&self, qs: Vec<Q>) -> Result<(), RequestError>
     where
-        Q: TryInto<RqliteQuery>,
+        Q: TryInto<RqliteQuery<'a>>,
         RequestError: From<Q::Error>,
     {
         let queries = qs

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -29,10 +29,9 @@ impl<'a> Serialize for RqliteArgument<'a> {
     }
 }
 
-// Implement RqliteArgumentRaw for RqliteArgumentValue
 impl<'a> RqliteArgumentRaw<'a> for RqliteArgumentValue<'a> {
     fn encode(&self) -> RqliteArgument<'a> {
-        RqliteArgument::Some(self.clone()) // We clone to return an owned value.
+        RqliteArgument::Some(self.clone())
     }
 }
 
@@ -113,6 +112,15 @@ mod tests {
 
     #[test]
     fn unit_rqlite_argument() {
+        let arg = arg!(1);
+        assert_eq!(arg, RqliteArgument::Some(RqliteArgumentValue::I64(1)));
+
+        let arg = arg!(1i32);
+        assert_eq!(arg, RqliteArgument::Some(RqliteArgumentValue::I64(1)));
+
+        let arg = arg!(1usize);
+        assert_eq!(arg, RqliteArgument::Some(RqliteArgumentValue::I64(1)));
+
         let arg = arg!(1i64);
         assert_eq!(arg, RqliteArgument::Some(RqliteArgumentValue::I64(1)));
 
@@ -145,5 +153,16 @@ mod tests {
 
         let arg = arg!(None::<RqliteArgumentValue>);
         assert_eq!(arg, RqliteArgument::None);
+    }
+
+    #[test]
+    fn unit_rqlite_serialize_option() {
+        let arg = RqliteArgument::Some(RqliteArgumentValue::I64(1));
+        let serialized = serde_json::to_string(&arg).unwrap();
+        assert_eq!(serialized, "1");
+
+        let arg = RqliteArgument::None;
+        let serialized = serde_json::to_string(&arg).unwrap();
+        assert_eq!(serialized, "null");
     }
 }

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -184,4 +184,70 @@ mod tests {
         let serialized = serde_json::to_string(&arg).unwrap();
         assert_eq!(serialized, "null");
     }
+
+    #[test]
+    fn unit_rqlite_argument_raw_owned() {
+        let arg = RqliteArgumentValue::String(Cow::Owned("hello".to_string()));
+        let encoded = arg.encode();
+        assert_eq!(
+            encoded,
+            RqliteArgument::Some(RqliteArgumentValue::String(Cow::Owned("hello".to_string())))
+        );
+
+        let arg = RqliteArgumentValue::I64(123);
+        let encoded = arg.encode();
+        assert_eq!(encoded, RqliteArgument::Some(RqliteArgumentValue::I64(123)));
+
+        let arg = RqliteArgumentValue::F64(3.2);
+        let encoded = arg.encode();
+        assert_eq!(encoded, RqliteArgument::Some(RqliteArgumentValue::F64(3.2)));
+
+        let arg = RqliteArgumentValue::F32(2.71);
+        let encoded = arg.encode();
+        assert_eq!(
+            encoded,
+            RqliteArgument::Some(RqliteArgumentValue::F32(2.71))
+        );
+
+        let arg = RqliteArgumentValue::Bool(true);
+        let encoded = arg.encode();
+        assert_eq!(
+            encoded,
+            RqliteArgument::Some(RqliteArgumentValue::Bool(true))
+        );
+    }
+
+    #[test]
+    #[allow(clippy::needless_borrow)]
+    fn unit_rqlite_argument_raw_borrowed() {
+        let arg = RqliteArgumentValue::String(Cow::Owned("hello".to_string()));
+        let encoded = (&arg).encode();
+        assert_eq!(
+            encoded,
+            RqliteArgument::Some(RqliteArgumentValue::String(Cow::Borrowed("hello")))
+        );
+
+        let arg = RqliteArgumentValue::I64(123);
+        let encoded = (&arg).encode();
+        assert_eq!(encoded, RqliteArgument::Some(RqliteArgumentValue::I64(123)));
+
+        let arg = RqliteArgumentValue::F64(3.2);
+        let encoded = (&arg).encode();
+        assert_eq!(encoded, RqliteArgument::Some(RqliteArgumentValue::F64(3.2)));
+
+        let arg = RqliteArgumentValue::F32(2.71);
+        let encoded = (&arg).encode();
+        assert_eq!(
+            encoded,
+            RqliteArgument::Some(RqliteArgumentValue::F32(2.71))
+        );
+
+        let arg = RqliteArgumentValue::Bool(true);
+
+        let encoded = (&arg).encode();
+        assert_eq!(
+            encoded,
+            RqliteArgument::Some(RqliteArgumentValue::Bool(true))
+        );
+    }
 }

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -46,6 +46,7 @@ impl<'a> RqliteArgumentRaw<'a> for RqliteArgumentValue<'a> {
     }
 }
 
+#[cfg_attr(tarpaulin, skip)]
 impl<'a> RqliteArgumentRaw<'a> for &'a RqliteArgumentValue<'a> {
     fn encode(&self) -> RqliteArgument<'a> {
         RqliteArgument::Some(match self {

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -46,7 +46,6 @@ impl<'a> RqliteArgumentRaw<'a> for RqliteArgumentValue<'a> {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
 impl<'a> RqliteArgumentRaw<'a> for &'a RqliteArgumentValue<'a> {
     fn encode(&self) -> RqliteArgument<'a> {
         RqliteArgument::Some(match self {

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -29,14 +29,33 @@ impl<'a> Serialize for RqliteArgument<'a> {
     }
 }
 
+pub trait RqliteArgumentRaw<'a> {
+    fn encode(&self) -> RqliteArgument<'a>;
+}
+
 impl<'a> RqliteArgumentRaw<'a> for RqliteArgumentValue<'a> {
     fn encode(&self) -> RqliteArgument<'a> {
-        RqliteArgument::Some(self.clone())
+        RqliteArgument::Some(match self {
+            // For String, just clone the ptr
+            RqliteArgumentValue::String(s) => RqliteArgumentValue::String(s.clone()),
+            RqliteArgumentValue::I64(val) => RqliteArgumentValue::I64(*val),
+            RqliteArgumentValue::F64(val) => RqliteArgumentValue::F64(*val),
+            RqliteArgumentValue::F32(val) => RqliteArgumentValue::F32(*val),
+            RqliteArgumentValue::Bool(val) => RqliteArgumentValue::Bool(*val),
+        })
     }
 }
 
-pub trait RqliteArgumentRaw<'a> {
-    fn encode(&self) -> RqliteArgument<'a>;
+impl<'a> RqliteArgumentRaw<'a> for &'a RqliteArgumentValue<'a> {
+    fn encode(&self) -> RqliteArgument<'a> {
+        RqliteArgument::Some(match self {
+            RqliteArgumentValue::String(s) => RqliteArgumentValue::String(Cow::Borrowed(s)),
+            RqliteArgumentValue::I64(val) => RqliteArgumentValue::I64(*val),
+            RqliteArgumentValue::F64(val) => RqliteArgumentValue::F64(*val),
+            RqliteArgumentValue::F32(val) => RqliteArgumentValue::F32(*val),
+            RqliteArgumentValue::Bool(val) => RqliteArgumentValue::Bool(*val),
+        })
+    }
 }
 
 impl<'a> RqliteArgumentRaw<'a> for i32 {


### PR DESCRIPTION
This PR resolves #15 

It adds support for using options. Take a look at [examples\option.rs](examples\option.rs) for an example (runnable via `cargo r --example option`).

I'd appreciate any feedback! :)

🚨*Warning*: This is includes a breaking change, since `RqliteArgument` was reimplemented from scratch