### PR TITLE
feat(rqlite-rs): support Option<T> arguments (#15) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add to your `Cargo.toml`:
 ```diff
 [dependencies]
 ...
-+ rqlite-rs = "0.3.20"
++ rqlite-rs = "0.4.0"
 ```
 
 ## Quick Start

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = "0.0.0"
 
 [dev-dependencies]
-rqlite-rs = { version = "0.3.20", path = "../rqlite-rs" }
+rqlite-rs = { version = "0.4.0", path = "../rqlite-rs" }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros"] }
 anyhow = "1.0.90"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -39,3 +39,8 @@ doc-scrape-examples = true
 name = "https"
 path = "https.rs"
 doc-scrape-examples = true
+
+[[example]]
+name = "option"
+path = "option.rs"
+doc-scrape-examples = true

--- a/examples/option.rs
+++ b/examples/option.rs
@@ -1,0 +1,65 @@
+use rqlite_rs::prelude::*;
+
+#[derive(FromRow)]
+pub struct OptionalRow {
+    id: i32,
+    optional: Option<i32>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = RqliteClientBuilder::new()
+        .known_host("localhost:4001")
+        .build()?;
+
+    let create_table_query = rqlite_rs::query!(
+        "CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, optional INTEGER)"
+    )?;
+
+    client.exec(create_table_query).await?;
+
+    let example_rows = [
+        OptionalRow {
+            id: 1,
+            optional: None,
+        },
+        OptionalRow {
+            id: 2,
+            optional: Some(2),
+        },
+    ];
+
+    let queries = example_rows
+        .iter()
+        .map(|row| {
+            rqlite_rs::query!(
+                "INSERT INTO test (id, optional) VALUES (?, ?)",
+                row.id,
+                row.optional
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let res = client.batch(queries).await?;
+
+    println!("Batch result: {:?}", res);
+
+    let select_query = rqlite_rs::query!("SELECT * FROM test")?;
+
+    let rows = client
+        .fetch(select_query)
+        .await?
+        .into_typed::<OptionalRow>()?;
+
+    rows.iter().for_each(|row| {
+        println!("ID: {}, Optional: {:?}", row.id, row.optional);
+    });
+
+    let drop_table_query = rqlite_rs::query!("DROP TABLE test")?;
+
+    client.exec(drop_table_query).await?;
+
+    println!("Successfully cleaned up");
+
+    Ok(())
+}

--- a/rqlite-rs/Cargo.toml
+++ b/rqlite-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rqlite-rs"
-version = "0.3.20"
+version = "0.4.0"
 publish = true
 description = "Async rqlite client for Rust"
 readme = "../README.md"

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -107,5 +107,11 @@ mod tests {
 
         let arg = arg!("hello".to_string());
         assert_eq!(arg, RqliteArgument::String("hello".to_string()));
+
+        let arg = arg!(Some(1i64));
+        assert_eq!(arg, RqliteArgument::I64(1));
+
+        let arg = arg!(None::<i64>);
+        assert_eq!(arg, RqliteArgument::Null);
     }
 }

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -8,12 +8,19 @@ pub enum RqliteArgument {
     F64(f64),
     F32(f32),
     Bool(bool),
+    Null,
 }
 
 impl RqliteArgument {}
 
 pub trait RqliteArgumentRaw {
     fn encode(&self) -> RqliteArgument;
+}
+
+impl RqliteArgumentRaw for i32 {
+    fn encode(&self) -> RqliteArgument {
+        RqliteArgument::I64(*self as i64)
+    }
 }
 
 impl RqliteArgumentRaw for i64 {
@@ -55,6 +62,18 @@ impl RqliteArgumentRaw for &str {
 impl RqliteArgumentRaw for String {
     fn encode(&self) -> RqliteArgument {
         RqliteArgument::String(self.to_string())
+    }
+}
+
+impl<T> RqliteArgumentRaw for Option<T>
+where
+    T: RqliteArgumentRaw,
+{
+    fn encode(&self) -> RqliteArgument {
+        match self {
+            Some(v) => v.encode(),
+            None => RqliteArgument::Null,
+        }
     }
 }
 


### PR DESCRIPTION
This PR resolves #15 and is an alternative and is favorable over #16.
The core advantages of this implementation are sticking to SemVer (/ keeping backwards compatibility) and simplicty.
Thanks @magwoo for assisting :)
