### PR TITLE
feat: added basic support for blobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ rust-version = "1.71.1"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.131"
 thiserror = "1.0.64"
+base64 = "0.22.1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = "0.0.0"
 
 [dev-dependencies]
-rqlite-rs = { version = "0.4.1", path = "../rqlite-rs" }
+rqlite-rs = { path = "../rqlite-rs", features = ["blob"] }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros"] }
 anyhow = "1.0.90"
 
@@ -43,4 +43,9 @@ doc-scrape-examples = true
 [[example]]
 name = "option"
 path = "option.rs"
+doc-scrape-examples = true
+
+[[example]]
+name = "blob"
+path = "blob.rs"
 doc-scrape-examples = true

--- a/examples/blob.rs
+++ b/examples/blob.rs
@@ -1,0 +1,51 @@
+use rqlite_rs::prelude::*;
+
+#[derive(FromRow, Debug)]
+pub struct Table {
+    id: i64,
+    blob: Vec<u8>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = RqliteClientBuilder::new()
+        .known_host("localhost:4001")
+        .build()?;
+
+    let drop_table = rqlite_rs::query!("DROP TABLE IF EXISTS blob_table")?;
+
+    client.exec(drop_table).await?;
+
+    let create_table = rqlite_rs::query!(
+        "CREATE TABLE IF NOT EXISTS blob_table (id INTEGER PRIMARY KEY, blob BLOB)"
+    )?;
+
+    client.exec(create_table).await?;
+
+    let insert_blob = rqlite_rs::query!(
+        "INSERT INTO blob_table (id, blob) VALUES (?, ?)",
+        1,
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    )?;
+
+    client.exec(insert_blob).await?;
+
+    let select_blob = rqlite_rs::query!("SELECT * FROM blob_table WHERE id = ?", 1)?;
+
+    let rows = client.fetch(select_blob).await?.into_typed::<Table>()?;
+
+    let row = rows.first().unwrap();
+
+    println!("{:?}", row);
+
+    assert_eq!(row.id, 1);
+    assert_eq!(row.blob, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+    let drop_table_query = rqlite_rs::query!("DROP TABLE blob_table")?;
+
+    client.exec(drop_table_query).await?;
+
+    println!("Successfully cleaned up");
+
+    Ok(())
+}

--- a/examples/option.rs
+++ b/examples/option.rs
@@ -12,6 +12,10 @@ async fn main() -> anyhow::Result<()> {
         .known_host("localhost:4001")
         .build()?;
 
+    let drop_table_query = rqlite_rs::query!("DROP TABLE IF EXISTS test")?;
+
+    client.exec(drop_table_query).await?;
+
     let create_table_query = rqlite_rs::query!(
         "CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, optional INTEGER)"
     )?;

--- a/rqlite-rs-core/Cargo.toml
+++ b/rqlite-rs-core/Cargo.toml
@@ -13,7 +13,11 @@ categories.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+blob = ["base64"]
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+base64 = { workspace = true, optional = true }

--- a/rqlite-rs-core/src/decode.rs
+++ b/rqlite-rs-core/src/decode.rs
@@ -1,0 +1,14 @@
+/// Decodes a base64 encoded string into a blob-like type.
+///
+/// # Errors
+///
+/// This function will return an error if the input string is not valid base64.
+#[cfg(feature = "blob")]
+pub fn decode_blob<T>(blob: &str) -> Result<T, base64::DecodeError>
+where
+    T: From<Vec<u8>>,
+{
+    use base64::{engine::general_purpose, Engine};
+
+    general_purpose::STANDARD.decode(blob).map(T::from)
+}

--- a/rqlite-rs-core/src/error.rs
+++ b/rqlite-rs-core/src/error.rs
@@ -11,4 +11,7 @@ pub enum IntoTypedError {
     ValueNotFound,
     #[error("Expected {0} columns, found {1}")]
     ColumnCountMismatch(usize, usize),
+    #[cfg(feature = "blob")]
+    #[error("Could not decode blob {0}")]
+    BlobDecodeError(#[from] base64::DecodeError),
 }

--- a/rqlite-rs-core/src/lib.rs
+++ b/rqlite-rs-core/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 mod column;
+pub mod decode;
 mod error;
 mod from_row;
 mod into_typed_rows;

--- a/rqlite-rs-macros/Cargo.toml
+++ b/rqlite-rs-macros/Cargo.toml
@@ -16,6 +16,9 @@ rust-version.workspace = true
 [lib]
 proc-macro = true
 
+[features]
+blob = ["rqlite-rs-core/blob"]
+
 [dependencies]
 quote = "1.0.37"
 rqlite-rs-core = { version = "0.2.12", path = "../rqlite-rs-core" }

--- a/rqlite-rs-macros/src/field_type.rs
+++ b/rqlite-rs-macros/src/field_type.rs
@@ -1,0 +1,51 @@
+use syn::Type;
+
+pub(crate) enum FieldType {
+    Option,
+    Blob,
+    Normal,
+}
+
+impl FieldType {
+    pub(crate) fn from_type_path(type_path: &syn::TypePath) -> Self {
+        if type_path.path.segments.last().unwrap().ident == "Option" {
+            return Self::Option;
+        }
+
+        #[cfg(feature = "blob")]
+        if is_vec_type(type_path) && has_u8_generic_arg(type_path) {
+            return Self::Blob;
+        }
+
+        Self::Normal
+    }
+}
+
+fn is_vec_type(type_path: &syn::TypePath) -> bool {
+    type_path
+        .path
+        .segments
+        .last()
+        .map_or(false, |seg| seg.ident == "Vec")
+}
+
+fn has_u8_generic_arg(type_path: &syn::TypePath) -> bool {
+    let Some(last_segment) = type_path.path.segments.last() else {
+        return false;
+    };
+
+    match &last_segment.arguments {
+        syn::PathArguments::AngleBracketed(args) => args.args.first().map_or(false, |arg| {
+            if let syn::GenericArgument::Type(Type::Path(inner_path)) = arg {
+                inner_path
+                    .path
+                    .segments
+                    .last()
+                    .map_or(false, |seg| seg.ident == "u8")
+            } else {
+                false
+            }
+        }),
+        _ => false,
+    }
+}

--- a/rqlite-rs/Cargo.toml
+++ b/rqlite-rs/Cargo.toml
@@ -20,12 +20,13 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 macros = ["rqlite-rs-macros"]
+blob = ["rqlite-rs-core/blob", "rqlite-rs-macros/blob"]
 
 [dependencies]
 rqlite-rs-macros = { version = "0.2.11", path = "../rqlite-rs-macros", optional = true }
 rqlite-rs-core = { version = "0.2.12", path = "../rqlite-rs-core" }
 reqwest = { version = "0.12.8", default-features = false }
-base64 = "0.22.1"
+base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/rqlite-rs/src/lib.rs
+++ b/rqlite-rs/src/lib.rs
@@ -19,6 +19,8 @@ pub(crate) mod select;
 #[cfg(feature = "macros")]
 pub use rqlite_rs_macros::*;
 
+pub use rqlite_rs_core::decode;
+
 pub mod prelude {
     pub use crate::client::RqliteClient;
     pub use crate::client::RqliteClientBuilder;

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine};
 use serde::Serialize;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
@@ -67,6 +68,20 @@ impl RqliteArgumentRaw for String {
     }
 }
 
+#[cfg(feature = "blob")]
+impl RqliteArgumentRaw for Vec<u8> {
+    fn encode(&self) -> RqliteArgument {
+        RqliteArgument::String(general_purpose::STANDARD.encode(self))
+    }
+}
+
+#[cfg(feature = "blob")]
+impl RqliteArgumentRaw for [u8] {
+    fn encode(&self) -> RqliteArgument {
+        RqliteArgument::String(general_purpose::STANDARD.encode(self))
+    }
+}
+
 impl<T> RqliteArgumentRaw for Option<T>
 where
     T: RqliteArgumentRaw,
@@ -118,5 +133,14 @@ mod tests {
 
         let arg = arg!(None::<i64>);
         assert_eq!(arg, RqliteArgument::Null);
+
+        #[cfg(feature = "blob")]
+        {
+            let arg = arg!(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            assert_eq!(arg, RqliteArgument::String("AQIDBAUGBwgJCg==".to_string()));
+
+            let arg = arg!([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            assert_eq!(arg, RqliteArgument::String("AQIDBAUGBwgJCg==".to_string()));
+        }
     }
 }


### PR DESCRIPTION
resolves #14

This PR aims to add support for blobs. 
There are two main ways to solve this:
1. Just add the ?blob_array query param (https://rqlite.io/docs/api/api/#blob-data)
2. Add custom logic for parsing base64

Variant 2 is preferable for performance reasons and minimizes request size.