### PR TITLE
feat: added basic support for blobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ rust-version = "1.71.1"
 serde = { version = "1.0.210", features = ["derive"] }
 serde_json = "1.0.131"
 thiserror = "1.0.64"
+base64 = "0.22.1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = "0.0.0"
 
 [dev-dependencies]
-rqlite-rs = { version = "0.4.1", path = "../rqlite-rs" }
+rqlite-rs = { path = "../rqlite-rs", features = ["blob"] }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros"] }
 anyhow = "1.0.90"
 
@@ -43,4 +43,9 @@ doc-scrape-examples = true
 [[example]]
 name = "option"
 path = "option.rs"
+doc-scrape-examples = true
+
+[[example]]
+name = "blob"
+path = "blob.rs"
 doc-scrape-examples = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = "0.0.0"
 
 [dev-dependencies]
-rqlite-rs = { path = "../rqlite-rs", features = ["blob"] }
+rqlite-rs = { path = "../rqlite-rs", features = [] }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros"] }
 anyhow = "1.0.90"
 

--- a/examples/blob.rs
+++ b/examples/blob.rs
@@ -1,0 +1,51 @@
+use rqlite_rs::prelude::*;
+
+#[derive(FromRow, Debug)]
+pub struct Table {
+    id: i64,
+    blob: Vec<u8>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = RqliteClientBuilder::new()
+        .known_host("localhost:4001")
+        .build()?;
+
+    let drop_table = rqlite_rs::query!("DROP TABLE IF EXISTS blob_table")?;
+
+    client.exec(drop_table).await?;
+
+    let create_table = rqlite_rs::query!(
+        "CREATE TABLE IF NOT EXISTS blob_table (id INTEGER PRIMARY KEY, blob BLOB)"
+    )?;
+
+    client.exec(create_table).await?;
+
+    let insert_blob = rqlite_rs::query!(
+        "INSERT INTO blob_table (id, blob) VALUES (?, ?)",
+        1,
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    )?;
+
+    client.exec(insert_blob).await?;
+
+    let select_blob = rqlite_rs::query!("SELECT * FROM blob_table WHERE id = ?", 1)?;
+
+    let rows = client.fetch(select_blob).await?.into_typed::<Table>()?;
+
+    let row = rows.first().unwrap();
+
+    println!("{:?}", row);
+
+    assert_eq!(row.id, 1);
+    assert_eq!(row.blob, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+    let drop_table_query = rqlite_rs::query!("DROP TABLE blob_table")?;
+
+    client.exec(drop_table_query).await?;
+
+    println!("Successfully cleaned up");
+
+    Ok(())
+}

--- a/examples/option.rs
+++ b/examples/option.rs
@@ -12,6 +12,10 @@ async fn main() -> anyhow::Result<()> {
         .known_host("localhost:4001")
         .build()?;
 
+    let drop_table_query = rqlite_rs::query!("DROP TABLE IF EXISTS test")?;
+
+    client.exec(drop_table_query).await?;
+
     let create_table_query = rqlite_rs::query!(
         "CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, optional INTEGER)"
     )?;

--- a/rqlite-rs-core/Cargo.toml
+++ b/rqlite-rs-core/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-blob = ["base64"]
+fast-blob = ["base64"]
 
 [dependencies]
 serde.workspace = true

--- a/rqlite-rs-core/Cargo.toml
+++ b/rqlite-rs-core/Cargo.toml
@@ -13,7 +13,11 @@ categories.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+blob = ["base64"]
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+base64 = { workspace = true, optional = true }

--- a/rqlite-rs-core/src/decode.rs
+++ b/rqlite-rs-core/src/decode.rs
@@ -3,7 +3,7 @@
 /// # Errors
 ///
 /// This function will return an error if the input string is not valid base64.
-#[cfg(feature = "blob")]
+#[cfg(feature = "fast-blob")]
 pub fn decode_blob<T>(blob: &str) -> Result<T, base64::DecodeError>
 where
     T: From<Vec<u8>>,
@@ -17,7 +17,7 @@ where
 mod tests {
 
     #[test]
-    #[cfg(feature = "blob")]
+    #[cfg(feature = "fast-blob")]
     fn unit_decode_blob() {
         use super::*;
 

--- a/rqlite-rs-core/src/decode.rs
+++ b/rqlite-rs-core/src/decode.rs
@@ -1,4 +1,4 @@
-/// Decodes a base64 encoded string into a blob-like type.
+/// Decodes a base64 encoded string into a blob-like type. This function is only available when the `blob` feature is enabled.
 ///
 /// # Errors
 ///

--- a/rqlite-rs-core/src/decode.rs
+++ b/rqlite-rs-core/src/decode.rs
@@ -12,3 +12,17 @@ where
 
     general_purpose::STANDARD.decode(blob).map(T::from)
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    #[cfg(feature = "blob")]
+    fn unit_decode_blob() {
+        use super::*;
+
+        let blob = "SGVsbG8gV29ybGQ=";
+        let decoded = decode_blob::<Vec<u8>>(blob).unwrap();
+        assert_eq!(decoded, b"Hello World");
+    }
+}

--- a/rqlite-rs-core/src/decode.rs
+++ b/rqlite-rs-core/src/decode.rs
@@ -1,0 +1,14 @@
+/// Decodes a base64 encoded string into a blob-like type.
+///
+/// # Errors
+///
+/// This function will return an error if the input string is not valid base64.
+#[cfg(feature = "blob")]
+pub fn decode_blob<T>(blob: &str) -> Result<T, base64::DecodeError>
+where
+    T: From<Vec<u8>>,
+{
+    use base64::{engine::general_purpose, Engine};
+
+    general_purpose::STANDARD.decode(blob).map(T::from)
+}

--- a/rqlite-rs-core/src/error.rs
+++ b/rqlite-rs-core/src/error.rs
@@ -11,4 +11,7 @@ pub enum IntoTypedError {
     ValueNotFound,
     #[error("Expected {0} columns, found {1}")]
     ColumnCountMismatch(usize, usize),
+    #[cfg(feature = "blob")]
+    #[error("Could not decode blob {0}")]
+    BlobDecodeError(#[from] base64::DecodeError),
 }

--- a/rqlite-rs-core/src/error.rs
+++ b/rqlite-rs-core/src/error.rs
@@ -11,7 +11,7 @@ pub enum IntoTypedError {
     ValueNotFound,
     #[error("Expected {0} columns, found {1}")]
     ColumnCountMismatch(usize, usize),
-    #[cfg(feature = "blob")]
+    #[cfg(feature = "fast-blob")]
     #[error("Could not decode blob {0}")]
     BlobDecodeError(#[from] base64::DecodeError),
 }

--- a/rqlite-rs-core/src/lib.rs
+++ b/rqlite-rs-core/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 mod column;
+pub mod decode;
 mod error;
 mod from_row;
 mod into_typed_rows;

--- a/rqlite-rs-macros/Cargo.toml
+++ b/rqlite-rs-macros/Cargo.toml
@@ -16,6 +16,9 @@ rust-version.workspace = true
 [lib]
 proc-macro = true
 
+[features]
+blob = ["rqlite-rs-core/blob"]
+
 [dependencies]
 quote = "1.0.37"
 rqlite-rs-core = { version = "0.2.12", path = "../rqlite-rs-core" }

--- a/rqlite-rs-macros/Cargo.toml
+++ b/rqlite-rs-macros/Cargo.toml
@@ -17,7 +17,7 @@ rust-version.workspace = true
 proc-macro = true
 
 [features]
-blob = ["rqlite-rs-core/blob"]
+fast-blob = ["rqlite-rs-core/fast-blob"]
 
 [dependencies]
 quote = "1.0.37"

--- a/rqlite-rs-macros/src/field_type.rs
+++ b/rqlite-rs-macros/src/field_type.rs
@@ -1,0 +1,51 @@
+use syn::Type;
+
+pub(crate) enum FieldType {
+    Option,
+    Blob,
+    Normal,
+}
+
+impl FieldType {
+    pub(crate) fn from_type_path(type_path: &syn::TypePath) -> Self {
+        if type_path.path.segments.last().unwrap().ident == "Option" {
+            return Self::Option;
+        }
+
+        #[cfg(feature = "blob")]
+        if is_vec_type(type_path) && has_u8_generic_arg(type_path) {
+            return Self::Blob;
+        }
+
+        Self::Normal
+    }
+}
+
+fn is_vec_type(type_path: &syn::TypePath) -> bool {
+    type_path
+        .path
+        .segments
+        .last()
+        .map_or(false, |seg| seg.ident == "Vec")
+}
+
+fn has_u8_generic_arg(type_path: &syn::TypePath) -> bool {
+    let Some(last_segment) = type_path.path.segments.last() else {
+        return false;
+    };
+
+    match &last_segment.arguments {
+        syn::PathArguments::AngleBracketed(args) => args.args.first().map_or(false, |arg| {
+            if let syn::GenericArgument::Type(Type::Path(inner_path)) = arg {
+                inner_path
+                    .path
+                    .segments
+                    .last()
+                    .map_or(false, |seg| seg.ident == "u8")
+            } else {
+                false
+            }
+        }),
+        _ => false,
+    }
+}

--- a/rqlite-rs-macros/src/field_type.rs
+++ b/rqlite-rs-macros/src/field_type.rs
@@ -12,7 +12,6 @@ impl FieldType {
             return Self::Option;
         }
 
-        #[cfg(feature = "blob")]
         if is_vec_type(type_path) && has_u8_generic_arg(type_path) {
             return Self::Blob;
         }

--- a/rqlite-rs-macros/src/lib.rs
+++ b/rqlite-rs-macros/src/lib.rs
@@ -27,13 +27,13 @@ pub fn derive_from_row(input: TokenStream) -> TokenStream {
                             #field_name: row.get_opt(#field_name_string)?
                         },
                         field_type::FieldType::Blob => {
-                            #[cfg(feature = "blob")]
+                            #[cfg(feature = "fast-blob")]
                             quote! {
                                 #field_name: rqlite_rs::decode::decode_blob(&row.get::<String>(#field_name_string)?)?
                             }
-                            #[cfg(not(feature = "blob"))]
+                            #[cfg(not(feature = "fast-blob"))]
                             quote! {
-                                compile_error!("The `blob` feature must be enabled to use the `Blob` field type")
+                                #field_name: row.get(#field_name_string)?
                             }
                         },
                         field_type::FieldType::Normal => quote! {
@@ -68,13 +68,13 @@ pub fn derive_from_row(input: TokenStream) -> TokenStream {
                             row.get_by_index_opt(#index)?
                         },
                         field_type::FieldType::Blob => {
-                            #[cfg(feature = "blob")]
+                            #[cfg(feature = "fast-blob")]
                             quote! {
                                 rqlite_rs::decode::decode_blob(&row.get_by_index::<String>(#index)?)?
                             }
-                            #[cfg(not(feature = "blob"))]
+                            #[cfg(not(feature = "fast-blob"))]
                             quote! {
-                                compile_error!("The `blob` feature must be enabled to use the `Blob` field type")
+                                row.get_by_index(#index)?
                             }
                         },
                         field_type::FieldType::Normal => quote! {

--- a/rqlite-rs/Cargo.toml
+++ b/rqlite-rs/Cargo.toml
@@ -20,12 +20,13 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 macros = ["rqlite-rs-macros"]
+blob = ["rqlite-rs-core/blob", "rqlite-rs-macros/blob"]
 
 [dependencies]
 rqlite-rs-macros = { version = "0.2.11", path = "../rqlite-rs-macros", optional = true }
 rqlite-rs-core = { version = "0.2.12", path = "../rqlite-rs-core" }
 reqwest = { version = "0.12.8", default-features = false }
-base64 = "0.22.1"
+base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/rqlite-rs/Cargo.toml
+++ b/rqlite-rs/Cargo.toml
@@ -20,7 +20,7 @@ native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 macros = ["rqlite-rs-macros"]
-blob = ["rqlite-rs-core/blob", "rqlite-rs-macros/blob"]
+fast-blob = ["rqlite-rs-core/fast-blob", "rqlite-rs-macros/fast-blob"]
 
 [dependencies]
 rqlite-rs-macros = { version = "0.2.11", path = "../rqlite-rs-macros", optional = true }

--- a/rqlite-rs/src/client.rs
+++ b/rqlite-rs/src/client.rs
@@ -63,6 +63,7 @@ impl RqliteClientBuilder {
     }
 
     /// Adds a default query parameter to the builder.
+    /// The `blob_array` parameter is added by default if the `fast-blob` feature is not enabled. (see <https://rqlite.io/docs/api/api/#blob-data>)
     #[must_use]
     pub fn default_query_params(mut self, params: Vec<RqliteQueryParam>) -> Self {
         self.config = self.config.default_query_params(params);
@@ -562,7 +563,10 @@ mod tests {
 
         let config = client.unwrap().config;
 
+        #[cfg(feature = "fast-blob")]
         assert_eq!(config.default_query_params.unwrap().0.len(), 1);
+        #[cfg(not(feature = "fast-blob"))]
+        assert_eq!(config.default_query_params.unwrap().0.len(), 2);
     }
 
     #[test]

--- a/rqlite-rs/src/lib.md
+++ b/rqlite-rs/src/lib.md
@@ -39,4 +39,4 @@ This will print all tables in the rqlite database.
 ## Features
 
 - **macros**: Use the `FromRow` derive macro to automatically convert rows to structs.
-- **blob**: Support for `Vec<u8>` and [u8] as a blob type.
+- **fast-blob**: When enabled, the client will use base64 encoding for retrieving blobs, reducing the amount of data transferred.

--- a/rqlite-rs/src/lib.md
+++ b/rqlite-rs/src/lib.md
@@ -35,3 +35,8 @@ async fn main() -> anyhow::Result<()> {
 ```
 
 This will print all tables in the rqlite database.
+
+## Features
+
+- **macros**: Use the `FromRow` derive macro to automatically convert rows to structs.
+- **blob**: Support for `Vec<u8>` and [u8] as a blob type.

--- a/rqlite-rs/src/lib.rs
+++ b/rqlite-rs/src/lib.rs
@@ -19,6 +19,8 @@ pub(crate) mod select;
 #[cfg(feature = "macros")]
 pub use rqlite_rs_macros::*;
 
+pub use rqlite_rs_core::decode;
+
 pub mod prelude {
     pub use crate::client::RqliteClient;
     pub use crate::client::RqliteClientBuilder;

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -139,7 +139,8 @@ mod tests {
             let arg = arg!(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
             assert_eq!(arg, RqliteArgument::String("AQIDBAUGBwgJCg==".to_string()));
 
-            let arg = arg!([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            let array = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            let arg = arg!(array[..]);
             assert_eq!(arg, RqliteArgument::String("AQIDBAUGBwgJCg==".to_string()));
         }
     }

--- a/rqlite-rs/src/query/arguments.rs
+++ b/rqlite-rs/src/query/arguments.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine};
 use serde::Serialize;
 
 #[derive(Debug, PartialEq, Serialize, Clone)]
@@ -67,6 +68,20 @@ impl RqliteArgumentRaw for String {
     }
 }
 
+#[cfg(feature = "blob")]
+impl RqliteArgumentRaw for Vec<u8> {
+    fn encode(&self) -> RqliteArgument {
+        RqliteArgument::String(general_purpose::STANDARD.encode(self))
+    }
+}
+
+#[cfg(feature = "blob")]
+impl RqliteArgumentRaw for [u8] {
+    fn encode(&self) -> RqliteArgument {
+        RqliteArgument::String(general_purpose::STANDARD.encode(self))
+    }
+}
+
 impl<T> RqliteArgumentRaw for Option<T>
 where
     T: RqliteArgumentRaw,
@@ -118,5 +133,14 @@ mod tests {
 
         let arg = arg!(None::<i64>);
         assert_eq!(arg, RqliteArgument::Null);
+
+        #[cfg(feature = "blob")]
+        {
+            let arg = arg!(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            assert_eq!(arg, RqliteArgument::String("AQIDBAUGBwgJCg==".to_string()));
+
+            let arg = arg!([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            assert_eq!(arg, RqliteArgument::String("AQIDBAUGBwgJCg==".to_string()));
+        }
     }
 }

--- a/rqlite-rs/src/request.rs
+++ b/rqlite-rs/src/request.rs
@@ -283,9 +283,9 @@ mod tests {
         let req_params = RequestQueryParams::from(params);
 
         #[cfg(feature = "fast-blob")]
-        assert_eq!(req_params.0.len(), 10);
-        #[cfg(not(feature = "fast-blob"))]
         assert_eq!(req_params.0.len(), 11);
+        #[cfg(not(feature = "fast-blob"))]
+        assert_eq!(req_params.0.len(), 12);
     }
 
     #[test]
@@ -296,9 +296,9 @@ mod tests {
         let reqwest_query = req_params.into_reqwest_query();
 
         #[cfg(feature = "fast-blob")]
-        assert_eq!(reqwest_query.len(), 10);
-        #[cfg(not(feature = "fast-blob"))]
         assert_eq!(reqwest_query.len(), 11);
+        #[cfg(not(feature = "fast-blob"))]
+        assert_eq!(reqwest_query.len(), 12);
     }
 
     #[test]
@@ -359,9 +359,9 @@ mod tests {
         let req_params = req.params.unwrap();
 
         #[cfg(feature = "fast-blob")]
-        assert_eq!(req_params.0.len(), 10);
-        #[cfg(not(feature = "fast-blob"))]
         assert_eq!(req_params.0.len(), 11);
+        #[cfg(not(feature = "fast-blob"))]
+        assert_eq!(req_params.0.len(), 12);
     }
 
     #[test]

--- a/rqlite-rs/src/request.rs
+++ b/rqlite-rs/src/request.rs
@@ -274,6 +274,7 @@ mod tests {
             .freshness_strict()
             .norwrandom()
             .ver("1".to_string())
+            .blob_array()
     }
 
     #[test]
@@ -337,6 +338,7 @@ mod tests {
         assert!(query.contains("freshness_strict=true"));
         assert!(query.contains("norwrandom=true"));
         assert!(query.contains("ver=1"));
+        assert!(query.contains("blob_array=true"));
     }
 
     #[test]

--- a/rqlite-rs/src/request.rs
+++ b/rqlite-rs/src/request.rs
@@ -142,6 +142,9 @@ pub enum RqliteQueryParam {
     NoRWRandom,
     /// Version
     Ver(String),
+    /// Retrieve blobs as u8 arrays instead of base64 encoded strings
+    /// Defaults to true when the `fast-blob` feature is disabled
+    BlobArray,
 }
 
 impl RqliteQueryParam {
@@ -163,6 +166,7 @@ impl RqliteQueryParam {
             }
             RqliteQueryParam::NoRWRandom => RequestQueryParam::Bool("norwrandom".to_string()),
             RqliteQueryParam::Ver(v) => RequestQueryParam::KV("ver".to_string(), v),
+            RqliteQueryParam::BlobArray => RequestQueryParam::Bool("blob_array".to_string()),
         }
     }
 }
@@ -223,6 +227,11 @@ impl RqliteQueryParams {
 
     pub fn ver(mut self, v: String) -> Self {
         self.0.push(RqliteQueryParam::Ver(v));
+        self
+    }
+
+    pub fn blob_array(mut self) -> Self {
+        self.0.push(RqliteQueryParam::BlobArray);
         self
     }
 

--- a/rqlite-rs/src/request.rs
+++ b/rqlite-rs/src/request.rs
@@ -282,7 +282,10 @@ mod tests {
         let params = full_query_params();
         let req_params = RequestQueryParams::from(params);
 
+        #[cfg(feature = "fast-blob")]
         assert_eq!(req_params.0.len(), 10);
+        #[cfg(not(feature = "fast-blob"))]
+        assert_eq!(req_params.0.len(), 11);
     }
 
     #[test]
@@ -292,7 +295,10 @@ mod tests {
 
         let reqwest_query = req_params.into_reqwest_query();
 
+        #[cfg(feature = "fast-blob")]
         assert_eq!(reqwest_query.len(), 10);
+        #[cfg(not(feature = "fast-blob"))]
+        assert_eq!(reqwest_query.len(), 11);
     }
 
     #[test]
@@ -352,7 +358,10 @@ mod tests {
 
         let req_params = req.params.unwrap();
 
+        #[cfg(feature = "fast-blob")]
         assert_eq!(req_params.0.len(), 10);
+        #[cfg(not(feature = "fast-blob"))]
+        assert_eq!(req_params.0.len(), 11);
     }
 
     #[test]


### PR DESCRIPTION
resolves #14

This PR aims to add support for blobs. 
There are two main ways to solve this:

1. Just add the ?blob_array query param (https://rqlite.io/docs/api/api/#blob-data)
2. Add custom logic for parsing base64

Variant 2 is preferable for performance reasons and minimizes request size.