### PR TITLE
feature: different fallback algorithms

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 version = "0.0.0"
 
 [dev-dependencies]
-rqlite-rs = { path = "../rqlite-rs", version = "0.5.0", features = [] }
+rqlite-rs = { path = "../rqlite-rs", features = ["random-fallback"] }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros"] }
 anyhow = "1.0.90"
 
@@ -48,4 +48,14 @@ doc-scrape-examples = true
 [[example]]
 name = "blob"
 path = "blob.rs"
+doc-scrape-examples = true
+
+[[example]]
+name = "random-fallback"
+path = "random-fallback.rs"
+doc-scrape-examples = true
+
+[[example]]
+name = "custom-fallback"
+path = "custom-fallback.rs"
 doc-scrape-examples = true

--- a/examples/custom-fallback.rs
+++ b/examples/custom-fallback.rs
@@ -31,14 +31,14 @@ impl FallbackStrategy for LeastFailuresFallback {
         let mut sorted_hosts = hosts.clone();
         sorted_hosts.sort_by_key(|host| failures.get(host).cloned().unwrap_or(0));
 
-        let next_host = sorted_hosts.iter().find(|&&ref host| host != current_host)?;
+        let next_host = sorted_hosts.iter().find(|&host| host != current_host)?;
 
         if persist {
             let index = hosts.iter().position(|host| host == next_host)?;
             hosts.swap(0, index);
             Some(&hosts[0])
         } else {
-            hosts.iter().find(|&&ref host| host == next_host)
+            hosts.iter().find(|&host| host == next_host)
         }
     }
 }

--- a/examples/custom-fallback.rs
+++ b/examples/custom-fallback.rs
@@ -1,0 +1,76 @@
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use rqlite_rs::{fallback::{FallbackCount, FallbackStrategy}, RqliteClientBuilder};
+
+#[derive(Default)]
+pub struct LeastFailuresFallback {
+    failures: Arc<Mutex<HashMap<String, u32>>>,
+}
+
+impl FallbackStrategy for LeastFailuresFallback {
+    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String> {
+        let mut failures = self.failures.lock().unwrap();
+
+        // Initialize the failures map if it is empty
+        if failures.is_empty() {
+            for host in hosts.iter() {
+                failures.insert(host.clone(), 0);
+            }
+        }
+
+        // Print the failures map if needed
+        // println!("failures: {:?}", failures);
+
+        // Report the current host as failed
+        if let Some(count) = failures.get_mut(current_host) {
+            *count += 1;
+        } else {
+            failures.insert(current_host.to_string(), 1);
+        }
+
+        let mut sorted_hosts = hosts.clone();
+        sorted_hosts.sort_by_key(|host| failures.get(host).cloned().unwrap_or(0));
+
+        let next_host = sorted_hosts.iter().find(|&&ref host| host != current_host)?;
+
+        if persist {
+            let index = hosts.iter().position(|host| host == next_host)?;
+            hosts.swap(0, index);
+            Some(&hosts[0])
+        } else {
+            hosts.iter().find(|&&ref host| host == next_host)
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = RqliteClientBuilder::new()
+        .known_host("localhost:4011")
+        .known_host("localhost:4009")
+        .known_host("localhost:4007")
+        .known_host("localhost:4005")
+        .known_host("localhost:4003")
+        .known_host("localhost:4001")
+        .fallback_strategy(LeastFailuresFallback::default())
+        .fallback_count(FallbackCount::Infinite)
+        .fallback_persistence(false)
+        .build()?;
+
+    loop {
+        let query = rqlite_rs::query!(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )?;
+
+        let rows = client.fetch(query).await;
+
+        let status = match rows {
+            Ok(_) => "OK".to_string(),
+            Err(e) => e.to_string(),
+        };
+
+        println!("Status: {}", status);
+
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+}

--- a/examples/custom-fallback.rs
+++ b/examples/custom-fallback.rs
@@ -1,6 +1,12 @@
-use std::{collections::HashMap, sync::{Arc, Mutex}};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
-use rqlite_rs::{fallback::{FallbackCount, FallbackStrategy}, RqliteClientBuilder};
+use rqlite_rs::{
+    fallback::{FallbackCount, FallbackStrategy},
+    RqliteClientBuilder,
+};
 
 #[derive(Default)]
 pub struct LeastFailuresFallback {
@@ -8,7 +14,12 @@ pub struct LeastFailuresFallback {
 }
 
 impl FallbackStrategy for LeastFailuresFallback {
-    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String> {
+    fn fallback<'a>(
+        &mut self,
+        hosts: &'a mut Vec<String>,
+        current_host: &str,
+        persist: bool,
+    ) -> Option<&'a String> {
         let mut failures = self.failures.lock().unwrap();
 
         // Initialize the failures map if it is empty

--- a/examples/random-fallback.rs
+++ b/examples/random-fallback.rs
@@ -1,4 +1,7 @@
-use rqlite_rs::{fallback::{FallbackCount, Random}, RqliteClientBuilder};
+use rqlite_rs::{
+    fallback::{FallbackCount, Random},
+    RqliteClientBuilder,
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/random-fallback.rs
+++ b/examples/random-fallback.rs
@@ -1,0 +1,33 @@
+use rqlite_rs::{fallback::{FallbackCount, Random}, RqliteClientBuilder};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let client = RqliteClientBuilder::new()
+        .known_host("localhost:4011")
+        .known_host("localhost:4009")
+        .known_host("localhost:4007")
+        .known_host("localhost:4005")
+        .known_host("localhost:4003")
+        .known_host("localhost:4001")
+        .fallback_strategy(Random::new_seed(42))
+        .fallback_count(FallbackCount::Infinite)
+        .fallback_persistence(false)
+        .build()?;
+
+    loop {
+        let query = rqlite_rs::query!(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )?;
+
+        let rows = client.fetch(query).await;
+
+        let status = match rows {
+            Ok(_) => "OK".to_string(),
+            Err(e) => e.to_string(),
+        };
+
+        println!("Status: {}", status);
+
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+}

--- a/rqlite-rs/Cargo.toml
+++ b/rqlite-rs/Cargo.toml
@@ -21,11 +21,13 @@ rustls-tls = ["reqwest/rustls-tls"]
 
 macros = ["rqlite-rs-macros"]
 fast-blob = ["rqlite-rs-core/fast-blob", "rqlite-rs-macros/fast-blob"]
+random-fallback = ["nanorand"]
 
 [dependencies]
 rqlite-rs-macros = { version = "0.3.0", path = "../rqlite-rs-macros", optional = true }
 rqlite-rs-core = { version = "0.3.0", path = "../rqlite-rs-core" }
 reqwest = { version = "0.12.8", default-features = false }
+nanorand = { version = "0.7.0", optional = true }
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/rqlite-rs/src/client.rs
+++ b/rqlite-rs/src/client.rs
@@ -1,7 +1,16 @@
 use std::sync::{Arc, RwLock};
 
 use crate::{
-    batch::BatchResult, config::{self, RqliteClientConfig, RqliteClientConfigBuilder}, error::{ClientBuilderError, RequestError}, fallback::{FallbackCount, FallbackStrategy}, node::{Node, NodeResponse, RemoveNodeRequest}, query::{self, QueryArgs, RqliteQuery}, query_result::QueryResult, request::{RequestOptions, RqliteQueryParam, RqliteQueryParams}, response::{RqliteResponseRaw, RqliteResult}, select::RqliteSelectResults
+    batch::BatchResult,
+    config::{self, RqliteClientConfig, RqliteClientConfigBuilder},
+    error::{ClientBuilderError, RequestError},
+    fallback::{FallbackCount, FallbackStrategy},
+    node::{Node, NodeResponse, RemoveNodeRequest},
+    query::{self, QueryArgs, RqliteQuery},
+    query_result::QueryResult,
+    request::{RequestOptions, RqliteQueryParam, RqliteQueryParams},
+    response::{RqliteResponseRaw, RqliteResult},
+    select::RqliteSelectResults,
 };
 use base64::{engine::general_purpose, Engine};
 use reqwest::header;
@@ -198,7 +207,11 @@ impl RqliteClient {
             let previous_host = host.clone();
             let mut writable_hosts = self.hosts.write().unwrap();
 
-            let new_host = self.config.fallback_strategy.write().unwrap()
+            let new_host = self
+                .config
+                .fallback_strategy
+                .write()
+                .unwrap()
                 .fallback(&mut writable_hosts, host, self.config.fallback_persistence)
                 .ok_or(RequestError::NoAvailableHosts)?;
 

--- a/rqlite-rs/src/client.rs
+++ b/rqlite-rs/src/client.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashSet, VecDeque},
-    sync::{Arc, RwLock},
-};
+use std::sync::{Arc, RwLock};
 
 use crate::{
     batch::BatchResult, config::{self, RqliteClientConfig, RqliteClientConfigBuilder}, error::{ClientBuilderError, RequestError}, fallback::{FallbackCount, FallbackStrategy}, node::{Node, NodeResponse, RemoveNodeRequest}, query::{self, QueryArgs, RqliteQuery}, query_result::QueryResult, request::{RequestOptions, RqliteQueryParam, RqliteQueryParams}, response::{RqliteResponseRaw, RqliteResult}, select::RqliteSelectResults
@@ -53,7 +50,7 @@ impl RqliteClientBuilder {
         let host_str = host.to_string();
 
         if self.hosts.iter().any(|h| h == &host_str) {
-            eprintln!("Host {} already exists", host_str);
+            eprintln!("Host {host_str} already exists");
         } else {
             self.hosts.push(host_str);
         }
@@ -116,7 +113,7 @@ impl RqliteClientBuilder {
 
         let hosts = self.hosts.into_iter().collect::<Vec<String>>();
 
-        println!("hosts: {:?}", hosts);
+        println!("hosts: {hosts:?}");
 
         let mut headers = header::HeaderMap::new();
         headers.insert(
@@ -155,7 +152,7 @@ impl RqliteClient {
     ) -> Result<reqwest::Response, RequestError> {
         let (mut host, host_count) = {
             let hosts = self.hosts.read().unwrap();
-            println!("hosts: {:?}", hosts);
+            println!("hosts: {hosts:?}");
             (hosts[0].clone(), hosts.len())
         };
 
@@ -166,7 +163,7 @@ impl RqliteClient {
         };
 
         for _ in 0..retry_count {
-            println!("Trying host: {}", host);
+            println!("Trying host: {host}");
             let req = options.to_reqwest_request(&self.client, host.as_str(), &self.config.scheme);
 
             match req.send().await {

--- a/rqlite-rs/src/config.rs
+++ b/rqlite-rs/src/config.rs
@@ -1,6 +1,9 @@
 use std::sync::RwLock;
 
-use crate::{fallback::{FallbackCount, FallbackStrategy}, request::{RequestQueryParams, RqliteQueryParam, RqliteQueryParams}};
+use crate::{
+    fallback::{FallbackCount, FallbackStrategy},
+    request::{RequestQueryParams, RqliteQueryParam, RqliteQueryParams},
+};
 
 #[derive(Default)]
 pub(crate) struct RqliteClientConfigBuilder {

--- a/rqlite-rs/src/config.rs
+++ b/rqlite-rs/src/config.rs
@@ -124,4 +124,44 @@ mod tests {
         assert_eq!(Scheme::Http.to_string(), "http");
         assert_eq!(Scheme::Https.to_string(), "https");
     }
+
+    // Fallback related tests
+    #[test]
+    fn unit_config_fallback_strategy() {
+        let config = RqliteClientConfigBuilder::default()
+            .fallback_strategy(crate::fallback::Priority::new(vec![
+                "localhost:4005".to_string(),
+                "localhost:4003".to_string(),
+                "localhost:4001".to_string(),
+            ]))
+            .build();
+
+        let mut fallback_strategy = config.fallback_strategy.write().unwrap();
+
+        assert!(fallback_strategy
+            .fallback(
+                &mut vec!["localhost:4001".to_string(), "localhost:4002".to_string()],
+                "localhost:4001",
+                false
+            )
+            .is_some());
+    }
+
+    #[test]
+    fn unit_config_fallback_count() {
+        let config = RqliteClientConfigBuilder::default()
+            .fallback_count(FallbackCount::Infinite)
+            .build();
+
+        assert!(matches!(config.fallback_count, FallbackCount::Infinite));
+    }
+
+    #[test]
+    fn unit_config_fallback_persistence() {
+        let config = RqliteClientConfigBuilder::default()
+            .fallback_persistence(true)
+            .build();
+
+        assert!(config.fallback_persistence);
+    }
 }

--- a/rqlite-rs/src/config.rs
+++ b/rqlite-rs/src/config.rs
@@ -1,14 +1,39 @@
-use crate::request::{RequestQueryParams, RqliteQueryParam, RqliteQueryParams};
+use std::sync::RwLock;
+
+use crate::{fallback::{FallbackCount, FallbackStrategy}, request::{RequestQueryParams, RqliteQueryParam, RqliteQueryParams}};
 
 #[derive(Default)]
 pub(crate) struct RqliteClientConfigBuilder {
     pub(crate) default_query_params: Option<RqliteQueryParams>,
     pub(crate) scheme: Option<Scheme>,
+    pub(crate) fallback_strategy: Option<Box<dyn FallbackStrategy>>,
+    pub(crate) fallback_count: Option<FallbackCount>,
+    pub(crate) fallback_persistence: bool,
 }
 
 impl RqliteClientConfigBuilder {
     pub(crate) fn default_query_params(mut self, params: Vec<RqliteQueryParam>) -> Self {
         self.default_query_params = Some(RqliteQueryParams::from(params));
+        self
+    }
+
+    pub(crate) fn scheme(mut self, scheme: Scheme) -> Self {
+        self.scheme = Some(scheme);
+        self
+    }
+
+    pub(crate) fn fallback_strategy(mut self, strategy: impl FallbackStrategy + 'static) -> Self {
+        self.fallback_strategy = Some(Box::new(strategy));
+        self
+    }
+
+    pub(crate) fn fallback_count(mut self, count: FallbackCount) -> Self {
+        self.fallback_count = Some(count);
+        self
+    }
+
+    pub(crate) fn fallback_persistence(mut self, persistence: bool) -> Self {
+        self.fallback_persistence = persistence;
         self
     }
 
@@ -35,12 +60,10 @@ impl RqliteClientConfigBuilder {
         RqliteClientConfig {
             default_query_params,
             scheme: self.scheme.unwrap_or(Scheme::Http),
+            fallback_strategy: RwLock::new(self.fallback_strategy.unwrap_or_default()),
+            fallback_count: self.fallback_count.unwrap_or_default(),
+            fallback_persistence: self.fallback_persistence,
         }
-    }
-
-    pub(crate) fn scheme(mut self, scheme: Scheme) -> Self {
-        self.scheme = Some(scheme);
-        self
     }
 }
 
@@ -48,6 +71,9 @@ impl RqliteClientConfigBuilder {
 pub(crate) struct RqliteClientConfig {
     pub(crate) default_query_params: Option<RequestQueryParams>,
     pub(crate) scheme: Scheme,
+    pub(crate) fallback_strategy: RwLock<Box<dyn FallbackStrategy>>,
+    pub(crate) fallback_count: FallbackCount,
+    pub(crate) fallback_persistence: bool,
 }
 
 #[derive(Default)]

--- a/rqlite-rs/src/fallback/mod.rs
+++ b/rqlite-rs/src/fallback/mod.rs
@@ -43,3 +43,19 @@ impl FallbackCount {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_fallback_count() {
+        assert_eq!(FallbackCount::NumHosts.count(3), 3);
+        assert_eq!(FallbackCount::None.count(3), 0);
+        assert_eq!(FallbackCount::Count(2).count(3), 2);
+        assert_eq!(FallbackCount::Count(4).count(3), 4);
+        assert_eq!(FallbackCount::Percentage(50).count(3), 2);
+        assert_eq!(FallbackCount::Percentage(200).count(3), 3);
+        assert_eq!(FallbackCount::Infinite.count(3), usize::MAX);
+    }
+}

--- a/rqlite-rs/src/fallback/mod.rs
+++ b/rqlite-rs/src/fallback/mod.rs
@@ -27,7 +27,11 @@ impl FallbackCount {
             FallbackCount::None => 0,
             FallbackCount::Count(count) => *count,
             FallbackCount::Percentage(percentage) => {
-                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+                #[allow(
+                    clippy::cast_sign_loss,
+                    clippy::cast_possible_truncation,
+                    clippy::cast_precision_loss
+                )]
                 let count = (hosts as f64 * (f64::from(*percentage) / 100.0)).ceil() as usize;
                 if count > hosts {
                     hosts

--- a/rqlite-rs/src/fallback/mod.rs
+++ b/rqlite-rs/src/fallback/mod.rs
@@ -10,7 +10,7 @@ pub enum FallbackCount {
     /// None means no fallback.
     None,
     /// A specific number of hosts to fallback to.
-    /// If the number is greater than the number of hosts, it will fallback to all hosts.
+    /// If the number is greater than the total number of hosts, it can lead to hosts being tried multiple times.
     Count(usize),
     /// A percentage of the total number of hosts to fallback to.
     /// If the percentage is greater than 100, it will fallback to all hosts.

--- a/rqlite-rs/src/fallback/mod.rs
+++ b/rqlite-rs/src/fallback/mod.rs
@@ -1,7 +1,7 @@
 mod strategy;
 pub use strategy::*;
 
-/// FallbackCount is the number of hosts to try to fallback to if the current host fails.
+/// `FallbackCount` is the number of hosts to try to fallback to if the current host fails.
 #[derive(Default)]
 pub enum FallbackCount {
     /// Equivalent to the current number of hosts.
@@ -27,7 +27,8 @@ impl FallbackCount {
             FallbackCount::None => 0,
             FallbackCount::Count(count) => *count,
             FallbackCount::Percentage(percentage) => {
-                let count = (hosts as f64 * (*percentage as f64 / 100.0)).ceil() as usize;
+                #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+                let count = (hosts as f64 * (f64::from(*percentage) / 100.0)).ceil() as usize;
                 if count > hosts {
                     hosts
                 } else {

--- a/rqlite-rs/src/fallback/mod.rs
+++ b/rqlite-rs/src/fallback/mod.rs
@@ -1,0 +1,40 @@
+mod strategy;
+pub use strategy::*;
+
+/// FallbackCount is the number of hosts to try to fallback to if the current host fails.
+#[derive(Default)]
+pub enum FallbackCount {
+    /// Equivalent to the current number of hosts.
+    #[default]
+    NumHosts,
+    /// None means no fallback.
+    None,
+    /// A specific number of hosts to fallback to.
+    /// If the number is greater than the number of hosts, it will fallback to all hosts.
+    Count(usize),
+    /// A percentage of the total number of hosts to fallback to.
+    /// If the percentage is greater than 100, it will fallback to all hosts.
+    Percentage(u8),
+    /// Never stop trying to fallback.
+    /// This is useful for testing purposes.
+    Infinite,
+}
+
+impl FallbackCount {
+    pub(crate) fn count(&self, hosts: usize) -> usize {
+        match self {
+            FallbackCount::NumHosts => hosts,
+            FallbackCount::None => 0,
+            FallbackCount::Count(count) => *count,
+            FallbackCount::Percentage(percentage) => {
+                let count = (hosts as f64 * (*percentage as f64 / 100.0)).ceil() as usize;
+                if count > hosts {
+                    hosts
+                } else {
+                    count
+                }
+            }
+            FallbackCount::Infinite => usize::MAX,
+        }
+    }
+}

--- a/rqlite-rs/src/fallback/strategy/mod.rs
+++ b/rqlite-rs/src/fallback/strategy/mod.rs
@@ -7,8 +7,8 @@ mod random;
 #[cfg(feature = "random-fallback")]
 pub use random::Random;
 
-/// FallbackStrategy is the trait that defines the strategy to use when a host fails.
-/// The default strategy is RoundRobin.
+/// `FallbackStrategy` is the trait that defines the strategy to use when a host fails.
+/// The default strategy is `RoundRobin`.
 pub trait FallbackStrategy {
     /// fallback returns the next host to try and can modify the hosts list if needed.
     fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String>;

--- a/rqlite-rs/src/fallback/strategy/mod.rs
+++ b/rqlite-rs/src/fallback/strategy/mod.rs
@@ -1,0 +1,21 @@
+mod round_robin;
+pub use round_robin::RoundRobin;
+mod priority;
+pub use priority::Priority;
+#[cfg(feature = "random-fallback")]
+mod random;
+#[cfg(feature = "random-fallback")]
+pub use random::Random;
+
+/// FallbackStrategy is the trait that defines the strategy to use when a host fails.
+/// The default strategy is RoundRobin.
+pub trait FallbackStrategy {
+    /// fallback returns the next host to try and can modify the hosts list if needed.
+    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String>;
+}
+
+impl Default for Box<dyn FallbackStrategy> {
+    fn default() -> Box<dyn FallbackStrategy> {
+        Box::new(round_robin::RoundRobin)
+    }
+}

--- a/rqlite-rs/src/fallback/strategy/mod.rs
+++ b/rqlite-rs/src/fallback/strategy/mod.rs
@@ -11,7 +11,12 @@ pub use random::Random;
 /// The default strategy is `RoundRobin`.
 pub trait FallbackStrategy {
     /// fallback returns the next host to try and can modify the hosts list if needed.
-    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String>;
+    fn fallback<'a>(
+        &mut self,
+        hosts: &'a mut Vec<String>,
+        current_host: &str,
+        persist: bool,
+    ) -> Option<&'a String>;
 }
 
 impl Default for Box<dyn FallbackStrategy> {

--- a/rqlite-rs/src/fallback/strategy/priority.rs
+++ b/rqlite-rs/src/fallback/strategy/priority.rs
@@ -4,11 +4,11 @@ use super::FallbackStrategy;
 /// This strategy will try the next host in the list.
 /// The list can be passed to the `Priority::new` function.
 /// If no list is passed, the hosts will be used in the order they were passed.
-/// 
+///
 /// # Example
 /// ```
 /// use rqlite_rs::{fallback::{FallbackCount, Priority}, RqliteClientBuilder};
-/// 
+///
 /// let client = RqliteClientBuilder::new()
 ///     .known_host("localhost:4005")
 ///     .known_host("localhost:4003")
@@ -19,7 +19,7 @@ use super::FallbackStrategy;
 ///         "localhost:4001".to_string(),
 ///     ]))
 ///     .build();
-/// 
+///
 /// assert!(client.is_ok());
 /// ```
 pub struct Priority {
@@ -27,15 +27,19 @@ pub struct Priority {
 }
 
 impl Priority {
-    #[must_use] pub fn new(hosts: Vec<String>) -> Priority {
-        Priority {
-            hosts,
-        }
+    #[must_use]
+    pub fn new(hosts: Vec<String>) -> Priority {
+        Priority { hosts }
     }
 }
 
 impl FallbackStrategy for Priority {
-    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String> {
+    fn fallback<'a>(
+        &mut self,
+        hosts: &'a mut Vec<String>,
+        current_host: &str,
+        persist: bool,
+    ) -> Option<&'a String> {
         // If hosts is empty, assume that the hosts were passed in order of priority.
         if self.hosts.is_empty() {
             self.hosts.clone_from(hosts);
@@ -44,7 +48,7 @@ impl FallbackStrategy for Priority {
         let index = self.hosts.iter().position(|host| host == current_host)?;
 
         let next_index = (index + 1) % self.hosts.len();
-        
+
         if persist {
             hosts.swap(0, next_index);
             Some(&hosts[0])

--- a/rqlite-rs/src/fallback/strategy/priority.rs
+++ b/rqlite-rs/src/fallback/strategy/priority.rs
@@ -27,7 +27,7 @@ pub struct Priority {
 }
 
 impl Priority {
-    pub fn new(hosts: Vec<String>) -> Priority {
+    #[must_use] pub fn new(hosts: Vec<String>) -> Priority {
         Priority {
             hosts,
         }
@@ -38,12 +38,10 @@ impl FallbackStrategy for Priority {
     fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String> {
         // If hosts is empty, assume that the hosts were passed in order of priority.
         if self.hosts.is_empty() {
-            self.hosts = hosts.clone();
+            self.hosts.clone_from(hosts);
         }
 
-        let Some(index) = self.hosts.iter().position(|host| host == current_host) else {
-            return None;
-        };
+        let index = self.hosts.iter().position(|host| host == current_host)?;
 
         let next_index = (index + 1) % self.hosts.len();
         

--- a/rqlite-rs/src/fallback/strategy/priority.rs
+++ b/rqlite-rs/src/fallback/strategy/priority.rs
@@ -1,0 +1,57 @@
+use super::FallbackStrategy;
+
+/// A priority strategy for fallback.
+/// This strategy will try the next host in the list.
+/// The list can be passed to the `Priority::new` function.
+/// If no list is passed, the hosts will be used in the order they were passed.
+/// 
+/// # Example
+/// ```
+/// use rqlite_rs::{fallback::{FallbackCount, Priority}, RqliteClientBuilder};
+/// 
+/// let client = RqliteClientBuilder::new()
+///     .known_host("localhost:4005")
+///     .known_host("localhost:4003")
+///     .known_host("localhost:4001")
+///     .fallback_strategy(Priority::new(vec![
+///         "localhost:4005".to_string(),
+///         "localhost:4003".to_string(),
+///         "localhost:4001".to_string(),
+///     ]))
+///     .build();
+/// 
+/// assert!(client.is_ok());
+/// ```
+pub struct Priority {
+    hosts: Vec<String>,
+}
+
+impl Priority {
+    pub fn new(hosts: Vec<String>) -> Priority {
+        Priority {
+            hosts,
+        }
+    }
+}
+
+impl FallbackStrategy for Priority {
+    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String> {
+        // If hosts is empty, assume that the hosts were passed in order of priority.
+        if self.hosts.is_empty() {
+            self.hosts = hosts.clone();
+        }
+
+        let Some(index) = self.hosts.iter().position(|host| host == current_host) else {
+            return None;
+        };
+
+        let next_index = (index + 1) % self.hosts.len();
+        
+        if persist {
+            hosts.swap(0, next_index);
+            Some(&hosts[0])
+        } else {
+            Some(&hosts[next_index])
+        }
+    }
+}

--- a/rqlite-rs/src/fallback/strategy/priority.rs
+++ b/rqlite-rs/src/fallback/strategy/priority.rs
@@ -57,3 +57,38 @@ impl FallbackStrategy for Priority {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_fallback_priority() {
+        let mut hosts = vec!["localhost:4001".to_string(), "localhost:4002".to_string()];
+        let mut strategy = Priority::new(vec![
+            "localhost:4001".to_string(),
+            "localhost:4002".to_string(),
+        ]);
+
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4001", false),
+            Some(&"localhost:4002".to_string())
+        );
+        assert_eq!(
+            hosts,
+            vec!["localhost:4001".to_string(), "localhost:4002".to_string()]
+        );
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4002", false),
+            Some(&"localhost:4001".to_string())
+        );
+        assert_eq!(
+            hosts,
+            vec!["localhost:4001".to_string(), "localhost:4002".to_string()]
+        );
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4001", true),
+            Some(&"localhost:4002".to_string())
+        );
+    }
+}

--- a/rqlite-rs/src/fallback/strategy/priority.rs
+++ b/rqlite-rs/src/fallback/strategy/priority.rs
@@ -45,7 +45,11 @@ impl FallbackStrategy for Priority {
             self.hosts.clone_from(hosts);
         }
 
-        let index = self.hosts.iter().position(|host| host == current_host)?;
+        let index = self
+            .hosts
+            .iter()
+            .position(|host| host == current_host)
+            .unwrap_or(0);
 
         let next_index = (index + 1) % self.hosts.len();
 

--- a/rqlite-rs/src/fallback/strategy/priority.rs
+++ b/rqlite-rs/src/fallback/strategy/priority.rs
@@ -95,4 +95,31 @@ mod tests {
             Some(&"localhost:4002".to_string())
         );
     }
+
+    #[test]
+    fn unit_fallback_priority_without_hosts() {
+        let mut hosts = vec!["localhost:4001".to_string(), "localhost:4002".to_string()];
+        let mut strategy = Priority::new(vec![]);
+
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4001", false),
+            Some(&"localhost:4002".to_string())
+        );
+        assert_eq!(
+            hosts,
+            vec!["localhost:4001".to_string(), "localhost:4002".to_string()]
+        );
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4002", false),
+            Some(&"localhost:4001".to_string())
+        );
+        assert_eq!(
+            hosts,
+            vec!["localhost:4001".to_string(), "localhost:4002".to_string()]
+        );
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4001", true),
+            Some(&"localhost:4002".to_string())
+        );
+    }
 }

--- a/rqlite-rs/src/fallback/strategy/priority.rs
+++ b/rqlite-rs/src/fallback/strategy/priority.rs
@@ -45,13 +45,12 @@ impl FallbackStrategy for Priority {
             self.hosts.clone_from(hosts);
         }
 
-        let index = self
-            .hosts
-            .iter()
-            .position(|host| host == current_host)
-            .unwrap_or(0);
+        let index = self.hosts.iter().position(|host| host == current_host);
 
-        let next_index = (index + 1) % self.hosts.len();
+        let next_index = match index {
+            Some(i) => (i + 1) % self.hosts.len(),
+            None => 0,
+        };
 
         if persist {
             hosts.swap(0, next_index);
@@ -120,6 +119,17 @@ mod tests {
         assert_eq!(
             strategy.fallback(&mut hosts, "localhost:4001", true),
             Some(&"localhost:4002".to_string())
+        );
+    }
+
+    #[test]
+    fn unit_fallback_non_existing_host() {
+        let mut hosts = vec!["localhost:4001".to_string(), "localhost:4002".to_string()];
+        let mut strategy = Priority::new(vec![]);
+
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4003", false),
+            Some(&"localhost:4001".to_string())
         );
     }
 }

--- a/rqlite-rs/src/fallback/strategy/random.rs
+++ b/rqlite-rs/src/fallback/strategy/random.rs
@@ -17,13 +17,15 @@ impl Default for Random {
 }
 
 impl Random {
-    #[must_use] pub fn new() -> Self {
+    #[must_use]
+    pub fn new() -> Self {
         Self {
             rng: nanorand::WyRand::new(),
         }
     }
 
-    #[must_use] pub fn new_seed(seed: u64) -> Self {
+    #[must_use]
+    pub fn new_seed(seed: u64) -> Self {
         Self {
             rng: nanorand::WyRand::new_seed(seed),
         }
@@ -31,7 +33,12 @@ impl Random {
 }
 
 impl FallbackStrategy for Random {
-    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, _current_host: &str, persist: bool) -> Option<&'a String> {
+    fn fallback<'a>(
+        &mut self,
+        hosts: &'a mut Vec<String>,
+        _current_host: &str,
+        persist: bool,
+    ) -> Option<&'a String> {
         let index = self.rng.generate_range(0..hosts.len());
         println!("persist: {persist}");
         if persist {

--- a/rqlite-rs/src/fallback/strategy/random.rs
+++ b/rqlite-rs/src/fallback/strategy/random.rs
@@ -68,4 +68,36 @@ mod tests {
             .fallback(&mut hosts, "localhost:4001", true)
             .is_some());
     }
+
+    #[test]
+    fn unit_fallback_random_default() {
+        let mut hosts = vec!["localhost:4001".to_string(), "localhost:4002".to_string()];
+        let mut strategy = Random::default();
+
+        assert!(strategy
+            .fallback(&mut hosts, "localhost:4001", false)
+            .is_some());
+        assert!(strategy
+            .fallback(&mut hosts, "localhost:4002", false)
+            .is_some());
+        assert!(strategy
+            .fallback(&mut hosts, "localhost:4001", true)
+            .is_some());
+    }
+
+    #[test]
+    fn unit_fallback_random_seed() {
+        let mut hosts = vec!["localhost:4001".to_string(), "localhost:4002".to_string()];
+        let mut strategy = Random::new_seed(42);
+
+        assert!(strategy
+            .fallback(&mut hosts, "localhost:4001", false)
+            .is_some());
+        assert!(strategy
+            .fallback(&mut hosts, "localhost:4002", false)
+            .is_some());
+        assert!(strategy
+            .fallback(&mut hosts, "localhost:4001", true)
+            .is_some());
+    }
 }

--- a/rqlite-rs/src/fallback/strategy/random.rs
+++ b/rqlite-rs/src/fallback/strategy/random.rs
@@ -3,7 +3,7 @@ use nanorand::Rng;
 
 use super::FallbackStrategy;
 
-/// Random is a FallbackStrategy that selects a random host from the list of hosts.
+/// Random is a `FallbackStrategy` that selects a random host from the list of hosts.
 /// This strategy will try a random host from the list.
 /// The list is taken as passed to the `RqliteClientBuilder`.
 pub struct Random {
@@ -17,13 +17,13 @@ impl Default for Random {
 }
 
 impl Random {
-    pub fn new() -> Self {
+    #[must_use] pub fn new() -> Self {
         Self {
             rng: nanorand::WyRand::new(),
         }
     }
 
-    pub fn new_seed(seed: u64) -> Self {
+    #[must_use] pub fn new_seed(seed: u64) -> Self {
         Self {
             rng: nanorand::WyRand::new_seed(seed),
         }
@@ -33,7 +33,7 @@ impl Random {
 impl FallbackStrategy for Random {
     fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, _current_host: &str, persist: bool) -> Option<&'a String> {
         let index = self.rng.generate_range(0..hosts.len());
-        println!("persist: {}", persist);
+        println!("persist: {persist}");
         if persist {
             hosts.swap(0, index);
             Some(&hosts[0])

--- a/rqlite-rs/src/fallback/strategy/random.rs
+++ b/rqlite-rs/src/fallback/strategy/random.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "random-fallback")]
+use nanorand::Rng;
+
+use super::FallbackStrategy;
+
+/// Random is a FallbackStrategy that selects a random host from the list of hosts.
+/// This strategy will try a random host from the list.
+/// The list is taken as passed to the `RqliteClientBuilder`.
+pub struct Random {
+    rng: nanorand::WyRand,
+}
+
+impl Default for Random {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Random {
+    pub fn new() -> Self {
+        Self {
+            rng: nanorand::WyRand::new(),
+        }
+    }
+
+    pub fn new_seed(seed: u64) -> Self {
+        Self {
+            rng: nanorand::WyRand::new_seed(seed),
+        }
+    }
+}
+
+impl FallbackStrategy for Random {
+    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, _current_host: &str, persist: bool) -> Option<&'a String> {
+        let index = self.rng.generate_range(0..hosts.len());
+        println!("persist: {}", persist);
+        if persist {
+            hosts.swap(0, index);
+            Some(&hosts[0])
+        } else {
+            Some(&hosts[index])
+        }
+    }
+}

--- a/rqlite-rs/src/fallback/strategy/random.rs
+++ b/rqlite-rs/src/fallback/strategy/random.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "random-fallback")]
 use nanorand::Rng;
 
 use super::FallbackStrategy;
@@ -47,5 +46,26 @@ impl FallbackStrategy for Random {
         } else {
             Some(&hosts[index])
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_fallback_random() {
+        let mut hosts = vec!["localhost:4001".to_string(), "localhost:4002".to_string()];
+        let mut strategy = Random::new();
+
+        assert!(strategy
+            .fallback(&mut hosts, "localhost:4001", false)
+            .is_some());
+        assert!(strategy
+            .fallback(&mut hosts, "localhost:4002", false)
+            .is_some());
+        assert!(strategy
+            .fallback(&mut hosts, "localhost:4001", true)
+            .is_some());
     }
 }

--- a/rqlite-rs/src/fallback/strategy/round_robin.rs
+++ b/rqlite-rs/src/fallback/strategy/round_robin.rs
@@ -29,3 +29,47 @@ impl FallbackStrategy for RoundRobin {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_fallback_round_robin() {
+        let mut hosts = vec!["localhost:4001".to_string(), "localhost:4002".to_string()];
+        let mut strategy = RoundRobin;
+
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4001", false),
+            Some(&"localhost:4002".to_string())
+        );
+        assert_eq!(
+            hosts,
+            vec!["localhost:4001".to_string(), "localhost:4002".to_string()]
+        );
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4002", false),
+            Some(&"localhost:4001".to_string())
+        );
+        assert_eq!(
+            hosts,
+            vec!["localhost:4001".to_string(), "localhost:4002".to_string()]
+        );
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4001", true),
+            Some(&"localhost:4002".to_string())
+        );
+        assert_eq!(
+            hosts,
+            vec!["localhost:4002".to_string(), "localhost:4001".to_string()]
+        );
+        assert_eq!(
+            strategy.fallback(&mut hosts, "localhost:4001", false),
+            Some(&"localhost:4002".to_string())
+        );
+        assert_eq!(
+            hosts,
+            vec!["localhost:4002".to_string(), "localhost:4001".to_string()]
+        );
+    }
+}

--- a/rqlite-rs/src/fallback/strategy/round_robin.rs
+++ b/rqlite-rs/src/fallback/strategy/round_robin.rs
@@ -13,7 +13,12 @@ impl RoundRobin {
 }
 
 impl FallbackStrategy for RoundRobin {
-    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String> {
+    fn fallback<'a>(
+        &mut self,
+        hosts: &'a mut Vec<String>,
+        current_host: &str,
+        persist: bool,
+    ) -> Option<&'a String> {
         if persist {
             Self::shift_hosts(hosts);
             Some(&hosts[0])

--- a/rqlite-rs/src/fallback/strategy/round_robin.rs
+++ b/rqlite-rs/src/fallback/strategy/round_robin.rs
@@ -13,12 +13,12 @@ impl RoundRobin {
 }
 
 impl FallbackStrategy for RoundRobin {
-    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, _current_host: &str, persist: bool) -> Option<&'a String> {
+    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, current_host: &str, persist: bool) -> Option<&'a String> {
         if persist {
             Self::shift_hosts(hosts);
             Some(&hosts[0])
         } else {
-            let index = hosts.iter().position(|host| host == _current_host)?;
+            let index = hosts.iter().position(|host| host == current_host)?;
             let next_index = (index + 1) % hosts.len();
             Some(&hosts[next_index])
         }

--- a/rqlite-rs/src/fallback/strategy/round_robin.rs
+++ b/rqlite-rs/src/fallback/strategy/round_robin.rs
@@ -1,0 +1,26 @@
+use super::FallbackStrategy;
+
+/// A round-robin strategy for fallback.
+/// This strategy will try the next host in the list.
+/// The list is taken as passed to the `RqliteClientBuilder`.
+pub struct RoundRobin;
+
+impl RoundRobin {
+    fn shift_hosts(hosts: &mut Vec<String>) {
+        let host = hosts.remove(0);
+        hosts.push(host);
+    }
+}
+
+impl FallbackStrategy for RoundRobin {
+    fn fallback<'a>(&mut self, hosts: &'a mut Vec<String>, _current_host: &str, persist: bool) -> Option<&'a String> {
+        if persist {
+            Self::shift_hosts(hosts);
+            Some(&hosts[0])
+        } else {
+            let index = hosts.iter().position(|host| host == _current_host)?;
+            let next_index = (index + 1) % hosts.len();
+            Some(&hosts[next_index])
+        }
+    }
+}

--- a/rqlite-rs/src/lib.md
+++ b/rqlite-rs/src/lib.md
@@ -37,6 +37,10 @@ async fn main() -> anyhow::Result<()> {
 This will print all tables in the rqlite database.
 
 ## Features
+The following features are available and out of these `macros` and `native-tls` are enabled by default:
 
 - **macros**: Use the `FromRow` derive macro to automatically convert rows to structs.
 - **fast-blob**: When enabled, the client will use base64 encoding for retrieving blobs, reducing the amount of data transferred.
+- **random-fallback**: This allows using a random known host as fallback when the primary host is unreachable. This is behind a feature flag because it requires an additional dependency.
+- **native-tls**: Use the reqwest native-tls backend for TLS connections.
+- **rustls-tls**: Use the reqwest rustls-tls backend for TLS connections.

--- a/rqlite-rs/src/lib.rs
+++ b/rqlite-rs/src/lib.rs
@@ -14,6 +14,7 @@ pub mod config;
 pub mod error;
 pub mod node;
 pub mod request;
+pub mod fallback;
 pub(crate) mod select;
 
 #[cfg(feature = "macros")]

--- a/rqlite-rs/src/lib.rs
+++ b/rqlite-rs/src/lib.rs
@@ -12,9 +12,9 @@ pub use rqlite_rs_core::*;
 pub mod batch;
 pub mod config;
 pub mod error;
+pub mod fallback;
 pub mod node;
 pub mod request;
-pub mod fallback;
 pub(crate) mod select;
 
 #[cfg(feature = "macros")]


### PR DESCRIPTION
This PR adds the possibility of choosing different algorithms for fallback or implementing custom ones using a trait (see [custom-fallback.rs](https://github.com/tomvoet/rqlite-rs/blob/48a3da79a458df1ade8d1b84e99ee36056023f18/examples/custom-fallback.rs)).
Furthermore the fallback count and persistence can also be adjusted.

The defaults for fallback strategy, -persistence and -count remain the same as before (RoundRobin, NumHosts, true).

