### PR TITLE
refactor: minimize deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/tomvoet/rqlite-rs"
 rust-version = "1.71.1"
 
 [workspace.dependencies]
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.131"
-thiserror = "1.0.64"
-base64 = "0.22.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+base64 = "0.22"

--- a/rqlite-rs-macros/Cargo.toml
+++ b/rqlite-rs-macros/Cargo.toml
@@ -20,6 +20,6 @@ proc-macro = true
 fast-blob = ["rqlite-rs-core/fast-blob"]
 
 [dependencies]
-quote = "1.0.37"
-rqlite-rs-core = { version = "0.3.0", path = "../rqlite-rs-core" }
-syn = { version = "2.0.79", features = ["full", "parsing"] }
+quote = "1"
+rqlite-rs-core = { version = "0.3", path = "../rqlite-rs-core" }
+syn = { version = "2", features = ["full", "parsing"] }

--- a/rqlite-rs-macros/Cargo.toml
+++ b/rqlite-rs-macros/Cargo.toml
@@ -21,5 +21,5 @@ fast-blob = ["rqlite-rs-core/fast-blob"]
 
 [dependencies]
 quote = "1"
-rqlite-rs-core = { version = "0.3", path = "../rqlite-rs-core" }
+rqlite-rs-core = { version = "0.3.0", path = "../rqlite-rs-core" }
 syn = { version = "2", features = ["full", "parsing"] }

--- a/rqlite-rs/Cargo.toml
+++ b/rqlite-rs/Cargo.toml
@@ -24,8 +24,8 @@ fast-blob = ["rqlite-rs-core/fast-blob", "rqlite-rs-macros/fast-blob"]
 random-fallback = ["nanorand"]
 
 [dependencies]
-rqlite-rs-macros = { version = "0.3", path = "../rqlite-rs-macros", optional = true }
-rqlite-rs-core = { version = "0.3", path = "../rqlite-rs-core" }
+rqlite-rs-macros = { version = "0.3.0", path = "../rqlite-rs-macros", optional = true }
+rqlite-rs-core = { version = "0.3.0", path = "../rqlite-rs-core" }
 reqwest = { version = "0.12", default-features = false }
 nanorand = { version = "0.7", optional = true }
 base64.workspace = true

--- a/rqlite-rs/Cargo.toml
+++ b/rqlite-rs/Cargo.toml
@@ -24,14 +24,14 @@ fast-blob = ["rqlite-rs-core/fast-blob", "rqlite-rs-macros/fast-blob"]
 random-fallback = ["nanorand"]
 
 [dependencies]
-rqlite-rs-macros = { version = "0.3.0", path = "../rqlite-rs-macros", optional = true }
-rqlite-rs-core = { version = "0.3.0", path = "../rqlite-rs-core" }
-reqwest = { version = "0.12.8", default-features = false }
-nanorand = { version = "0.7.0", optional = true }
+rqlite-rs-macros = { version = "0.3", path = "../rqlite-rs-macros", optional = true }
+rqlite-rs-core = { version = "0.3", path = "../rqlite-rs-core" }
+reqwest = { version = "0.12", default-features = false }
+nanorand = { version = "0.7", optional = true }
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-tokio = "1.40.0"
+tokio = "1"


### PR DESCRIPTION
updating dependency versions to the most flexible while maintaining compatibility for minimize dependencies in projects

### Eg.
my project uses `reqwest="0.12.12"`, and rqlite-rs adds `reqwest="0.12.8"`, but they can safely use `v0.12.12` both.

### Decision
since packages have to follow SemVer, we can safely use unstable versions (0.x) like `"0.12"` and stable versions (>=1.x) like `"1"`.

*sorry for my possibly poor English, I am writing this text combining my knowledge of the language with a translator)*