### PR TITLE
refactor: replace println with tracing for structured logging

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 [dev-dependencies]
 rqlite-rs = { path = "../rqlite-rs", features = ["random-fallback"] }
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "macros"] }
+tracing-subscriber = "0.3"
 anyhow = "1.0.90"
 
 [[example]]

--- a/examples/fallback-node.rs
+++ b/examples/fallback-node.rs
@@ -2,6 +2,8 @@ use rqlite_rs::prelude::*;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
     let client = RqliteClientBuilder::new()
         .known_host("localhost:4002")
         .known_host("localhost:4001")

--- a/rqlite-rs/Cargo.toml
+++ b/rqlite-rs/Cargo.toml
@@ -28,6 +28,7 @@ rqlite-rs-macros = { version = "0.3.2", path = "../rqlite-rs-macros", optional =
 rqlite-rs-core = { version = "0.3.2", path = "../rqlite-rs-core" }
 reqwest = { version = "0.12", default-features = false }
 nanorand = { version = "0.7", optional = true }
+tracing = "0.1"
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/rqlite-rs/src/client.rs
+++ b/rqlite-rs/src/client.rs
@@ -59,7 +59,7 @@ impl RqliteClientBuilder {
         let host_str = host.to_string();
 
         if self.hosts.iter().any(|h| h == &host_str) {
-            eprintln!("Host {host_str} already exists");
+            tracing::warn!("Host {host_str} already exists");
         } else {
             self.hosts.push(host_str);
         }
@@ -169,7 +169,7 @@ impl RqliteClient {
         };
 
         for _ in 0..retry_count {
-            println!("Trying host: {host}");
+            tracing::debug!("Trying host: {host}");
             let req = options.to_reqwest_request(&self.client, host.as_str(), &self.config.scheme);
 
             match req.send().await {
@@ -213,7 +213,7 @@ impl RqliteClient {
                 .ok_or(RequestError::NoAvailableHosts)?;
 
             host.clone_from(new_host);
-            println!("Connection to {} failed, trying {}", previous_host, *host);
+            tracing::info!("Connection to {} failed, trying {}", previous_host, *host);
             Ok(())
         } else {
             Err(RequestError::SwitchoverWrongError(e.to_string()))


### PR DESCRIPTION
Replaces `println!`/`eprintln!` statements with `tracing` macros for proper library logging.

Consumers can now control log output by attaching a tracing subscriber. No output is produced by default.

Adds `fallback-node` example demonstrating subscriber setup.